### PR TITLE
Use latest version for gke

### DIFF
--- a/scripts/istio.env
+++ b/scripts/istio.env
@@ -64,5 +64,5 @@ ISTIO_AUTH_POLICY="MUTUAL_TLS"
 # For "hosted istio", the GKE version and the istio version must match according
 # to the table "Supported Cluster Versions":
 # https://cloud.google.com/istio/docs/istio-on-gke/installing
-ISTIO_GKE_VERSION="1.0.3-gke.3"
-GKE_VERSION="1.11.7-gke.4"
+ISTIO_GKE_VERSION="1.0.3-gke.3a"
+GKE_VERSION="1.12.5-gke.5"

--- a/scripts/teardown.sh
+++ b/scripts/teardown.sh
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
 set -x
 
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"


### PR DESCRIPTION
Update the gke version to latest and set the istio version to one installed by GKE with managed istio.